### PR TITLE
Fix bug of user setting reset on comment post

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -101,7 +101,7 @@ public class DataServlet extends HttpServlet {
       datastore.put(commentEntity);
     }
 
-    response.sendRedirect("/index.html#comments");
+    response.sendRedirect("/index.html?comments=true&num-comments=10&sort-comments=latest");
   }
 
   /**

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -87,6 +87,8 @@ public class DataServlet extends HttpServlet {
     String commentText = getParameter(request, "comment-input", "");
     String username = getParameter(request, "username", "Anonymous");
     String password = getParameter(request, "pwd", "");
+    String maxNumComments = getParameter(request, "num-comments", "10");
+    String sortType = getParameter(request, "sort-comments", "latest");
 
     if (!commentText.isEmpty()) {
       long timestamp = System.currentTimeMillis();
@@ -101,7 +103,7 @@ public class DataServlet extends HttpServlet {
       datastore.put(commentEntity);
     }
 
-    response.sendRedirect("/index.html?comments=true&num-comments=10&sort-comments=latest");
+    response.sendRedirect("/index.html?comments=true&num-comments="+maxNumComments+"&sort-comments="+sortType);
   }
 
   /**

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <script src="script.js"></script>
-  <body onload="getCommentsfromServer()">
+  <body onload="onload()">
     <ul id="navbar">
       <li><a href="#home">Home</a>
       <li><a href="#intro">About Me</a>
@@ -92,10 +92,10 @@
       <div id="comments-style">
         <label for="num-comments">Maximum number of comments to show:</label>
         <select name="num-comments" id="num-comments" form="comment-form" onchange="getCommentsfromServer()">
-          <option value="5">5</option>
-          <option value="10">10</option>
-          <option value="15">15</option>
-          <option value="20">20</option>
+          <option id="5" value="5">5</option>
+          <option id="10" value="10">10</option>
+          <option id="15" value="15">15</option>
+          <option id="20" value="20">20</option>
         </select>
 
         <form id="comment-form" action="/data" method="POST">
@@ -111,10 +111,10 @@
 
         <label for="sort-comments">Sort by:</label>
         <select name="sort-comments" id="sort-comments" onchange="getCommentsfromServer()">
-          <option value="latest">Latest</option>
-          <option value="oldest">Oldest</option>
-          <option value="name_ascend">Name(A-Z)</option>
-          <option value="name_descend">Name(Z-A)</option>
+          <option id="latest" value="latest">Latest</option>
+          <option id="oldest" value="oldest">Oldest</option>
+          <option id="name_ascend" value="name_ascend">Name(A-Z)</option>
+          <option id="name_descend" value="name_descend">Name(Z-A)</option>
         </select>
         <ul id="comments-container"></ul>
       </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -107,6 +107,9 @@
           
           <textarea id="comment" name="comment-input" placeholder="Leave your comment here!"></textarea>
           <input type="submit" />
+
+          <input type="text" name="num-comments" class="invisible-form" id="comment-form-num-comments">
+          <input type="text" name="sort-comments" class="invisible-form" id="comment-form-sort-comments">
         </form>
 
         <label for="sort-comments">Sort by:</label>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -129,16 +129,38 @@ async function deleteResult() {
   alert(matchResult);
 }
 
-/**
- * Fetch comments from the server and display it on the page
- */
-async function getCommentsfromServer() {
+function setSelectValues() {
+  let params = (new URL(document.location)).searchParams;
+  let maxNumComments = params.get("num-comments");
+  let sortType = params.get("sort-comments");
+  let comment = params.get("comments");
+  if (maxNumComments) {
+    document.getElementById(maxNumComments).setAttribute("selected", "selected");
+  }
+  if (sortType) {
+    document.getElementById(sortType).setAttribute("selected", "selected");
+  }
+  if (comments) {
+    window.history.replaceState({}, document.title, "/" + "index.html");
+    window.location.hash = "#comments";
+  }
+}
+
+function generateUrlQuery() {
   const maxNumComments = document.getElementById("num-comments").value;
   const sortType = document.getElementById("sort-comments").value;
 
   var searchParams = new URLSearchParams();
   searchParams.append("num-comments", maxNumComments);
   searchParams.append("sort-comments", sortType);
+  return searchParams;
+}
+
+/**
+ * Fetch comments from the server and display it on the page
+ */
+async function getCommentsfromServer() {
+  var searchParams = generateUrlQuery();
 
   const response = await fetch('/data?' + searchParams);
   const comments = await response.json();
@@ -149,4 +171,9 @@ async function getCommentsfromServer() {
   for (var i = 0; i < comments.length; i++) {
     commentsListElement.appendChild(createCommentsListElement(comments[i]));
   }
+}
+
+function onload() {
+  setSelectValues();
+  getCommentsfromServer();
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -130,10 +130,10 @@ async function deleteResult() {
 }
 
 function setSelectValues() {
-  let params = (new URL(document.location)).searchParams;
-  let maxNumComments = params.get("num-comments");
-  let sortType = params.get("sort-comments");
-  let comments = params.get("comments");
+  const params = (new URL(document.location)).searchParams;
+  const maxNumComments = params.get("num-comments");
+  const sortType = params.get("sort-comments");
+  const comments = params.get("comments");
   if (maxNumComments) {
     console.log(maxNumComments);
     document.getElementById(maxNumComments).setAttribute("selected", "selected");
@@ -155,7 +155,7 @@ function generateUrlQuery() {
   document.getElementById("comment-form-num-comments").setAttribute("value", maxNumComments);
   document.getElementById("comment-form-sort-comments").setAttribute("value", sortType);
 
-  var searchParams = new URLSearchParams();
+  const searchParams = new URLSearchParams();
   searchParams.append("num-comments", maxNumComments);
   searchParams.append("sort-comments", sortType);
   return searchParams;
@@ -165,7 +165,7 @@ function generateUrlQuery() {
  * Fetch comments from the server and display it on the page
  */
 async function getCommentsfromServer() {
-  var searchParams = generateUrlQuery();
+  const searchParams = generateUrlQuery();
 
   const response = await fetch('/data?' + searchParams);
   const comments = await response.json();

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -105,7 +105,7 @@ function createPasswordForm(comment) {
   commentID.setAttribute('type', 'text');
   commentID.setAttribute('name', "id");
   commentID.setAttribute('value', comment.id);
-  commentID.className = "comment-id";
+  commentID.className = "invisible-form";
 
   const submitButton = document.createElement('input');
   submitButton.setAttribute('type', "submit");
@@ -133,11 +133,13 @@ function setSelectValues() {
   let params = (new URL(document.location)).searchParams;
   let maxNumComments = params.get("num-comments");
   let sortType = params.get("sort-comments");
-  let comment = params.get("comments");
+  let comments = params.get("comments");
   if (maxNumComments) {
+    console.log(maxNumComments);
     document.getElementById(maxNumComments).setAttribute("selected", "selected");
   }
   if (sortType) {
+    console.log(sortType);
     document.getElementById(sortType).setAttribute("selected", "selected");
   }
   if (comments) {
@@ -149,6 +151,9 @@ function setSelectValues() {
 function generateUrlQuery() {
   const maxNumComments = document.getElementById("num-comments").value;
   const sortType = document.getElementById("sort-comments").value;
+
+  document.getElementById("comment-form-num-comments").setAttribute("value", maxNumComments);
+  document.getElementById("comment-form-sort-comments").setAttribute("value", sortType);
 
   var searchParams = new URLSearchParams();
   searchParams.append("num-comments", maxNumComments);

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -320,7 +320,7 @@ h3 {
   padding: 12px 12px;
 }
 
-.comment-id {
+.invisible-form {
   visibility: hidden;
 }
 


### PR DESCRIPTION
Previously, when user posts the comment, the page gets reloaded from the server, and the user's preference regarding sorting order and number of comments displayed got reset to the default value. To fix this bug, I created a invisible section of the form that stores current user's setting so that server can access those values on form's POST request. Then, when it redirects, server can attach these values as parameters in URL, where script.js parses the url parameters and sets the values of the select form accordingly on page load. 