### PR TITLE
Translate comments using google cloud translate api

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -34,6 +34,12 @@
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-translate</artifactId>
+      <version>1.70.0</version>
     </dependency>    
   </dependencies>
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -44,7 +44,7 @@ public class DataServlet extends HttpServlet {
     return json;
   }
 
-  private List<Comment> getComments(int maxNumComments, String sortType) {
+  private List<Comment> getComments(int maxNumComments, String sortType, String language) {
     Query query = new Query("Comment");
     switch (sortType) {
       case "latest":
@@ -59,8 +59,10 @@ public class DataServlet extends HttpServlet {
       case "name_descend":
         query.addSort("username", SortDirection.DESCENDING);
     }
+
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
+    Translate translate = TranslateOptions.getDefaultInstance().getService();
 
     List<Comment> comments = new ArrayList<>();
     for (Entity entity : results.asIterable(FetchOptions.Builder.withLimit(maxNumComments))) {
@@ -69,8 +71,10 @@ public class DataServlet extends HttpServlet {
       String password = (String) entity.getProperty("password");
       long timestamp = (long) entity.getProperty("timestamp");
       String commentText = (String) entity.getProperty("text");
+      Translation translation = translate.translate(commentText, Translate.TranslateOption.targetLanguage(language));
+      String translatedText = translation.getTranslatedText();
 
-      Comment comment = new Comment (id, username, password, timestamp, commentText);
+      Comment comment = new Comment (id, username, password, timestamp, translatedText);
       comments.add(comment);
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -74,7 +74,7 @@ public class DataServlet extends HttpServlet {
       Translation translation = translate.translate(commentText, Translate.TranslateOption.targetLanguage(language));
       String translatedText = translation.getTranslatedText();
 
-      Comment comment = new Comment (id, username, password, timestamp, translatedText);
+      Comment comment = new Comment(id, username, password, timestamp, translatedText);
       comments.add(comment);
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -89,7 +89,8 @@ public class DataServlet extends HttpServlet {
 
     List<Comment> comments = getComments(maxNumComments, sortType, language);
 
-    response.setContentType("application/json;");
+    response.setContentType("application/json; charset=UTF-8");
+    response.setCharacterEncoding("UTF-8");
     response.getWriter().println(convertToJson(comments));
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -26,6 +26,9 @@ import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.cloud.translate.Translate;
+import com.google.cloud.translate.TranslateOptions;
+import com.google.cloud.translate.Translation;
 import java.util.ArrayList;
 import java.util.List;
 import com.google.gson.Gson;
@@ -78,7 +81,9 @@ public class DataServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     int maxNumComments = Integer.parseInt(getParameter(request, "num-comments", "5"));
     String sortType = getParameter(request, "sort-comments", "latest");
-    List<Comment> comments = getComments(maxNumComments, sortType);
+    String language = getParameter(request, "lang-comments", "en");
+
+    List<Comment> comments = getComments(maxNumComments, sortType, language);
 
     response.setContentType("application/json;");
     response.getWriter().println(convertToJson(comments));

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -90,6 +90,15 @@
     <div id="comments">
       <h2>Comments</h2>
       <div id="comments-style">
+        <label for="lang-comments">Display comments in:</label>
+        <select name="lang-comments" id="lang-comments" onchange="getCommentsfromServer()">
+          <option id ="en" value="en">English</option>
+          <option id ="zh" value="zh">Chinese</option>
+          <option id ="es" value="es">Spanish</option>
+          <option id ="ar" value="ar">Arabic</option>
+          <option id ="ko" value="ko">Korean</option>
+        </select>
+
         <label for="num-comments">Maximum number of comments to show:</label>
         <select name="num-comments" id="num-comments" form="comment-form" onchange="getCommentsfromServer()">
           <option id="5" value="5">5</option>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -151,6 +151,7 @@ function setSelectValues() {
 function generateUrlQuery() {
   const maxNumComments = document.getElementById("num-comments").value;
   const sortType = document.getElementById("sort-comments").value;
+  const language = document.getElementById("lang-comments").value;
 
   document.getElementById("comment-form-num-comments").setAttribute("value", maxNumComments);
   document.getElementById("comment-form-sort-comments").setAttribute("value", sortType);
@@ -158,6 +159,7 @@ function generateUrlQuery() {
   const searchParams = new URLSearchParams();
   searchParams.append("num-comments", maxNumComments);
   searchParams.append("sort-comments", sortType);
+  searchParams.append("lang-comments", language);
   return searchParams;
 }
 


### PR DESCRIPTION
This feature allows users to display the comments based on their preferred language in the language select dropdown menu. It translates the comments in the server using google cloud translate api. To display non-english texts, character encoding of the comments are set to utf-8. 