### PR TITLE
Allow users to choose maximum number of bigfoot sightings to be displayed

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/BigfootDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/BigfootDataServlet.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Scanner;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -15,7 +16,7 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/bigfoot-data")
 public class BigfootDataServlet extends HttpServlet {
   
-  private Collection<BigfootSighting> bigfootSightings;
+  private ArrayList<BigfootSighting> bigfootSightings;
 
   @Override 
   public void init() {
@@ -36,13 +37,15 @@ public class BigfootDataServlet extends HttpServlet {
       bigfootSightings.add(new BigfootSighting(latitude, longitude));
     }
     scanner.close();
+    Collections.shuffle(bigfootSightings);
   }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    int maxNumBigfoot = Integer.parseInt(request.getParameter("num-bigfoot"));
     response.setContentType("application/json");
     Gson gson = new Gson();
-    String json = gson.toJson(bigfootSightings);
+    String json = gson.toJson(bigfootSightings.subList(0, maxNumBigfoot));
     response.getWriter().println(json);
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/BigfootDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/BigfootDataServlet.java
@@ -42,7 +42,12 @@ public class BigfootDataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    int maxNumBigfoot = Integer.parseInt(request.getParameter("num-bigfoot"));
+    int maxNumBigfoot;
+    try { 
+      maxNumBigfoot = Integer.parseInt(request.getParameter("num-bigfoot"));
+    } catch (Exception e) {
+      maxNumBigfoot = bigfootSightings.size();
+    }
     response.setContentType("application/json");
     Gson gson = new Gson();
     String json = gson.toJson(bigfootSightings.subList(0, maxNumBigfoot));

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -211,8 +211,7 @@ function createOptionElement(value) {
   return optionElement
 }
 
-/** Fetches bigfoot sightings data from the server and displays it in a map. */
-async function createBigfootSightingsMap() {
+function createNumBigfootSelect() {
   const messageContainer = document.getElementById("map-descriptor");
   messageContainer.innerText = "Choose number of random sightings of bigfoot to display 🦧:"
   const selectNumBigfoot = document.createElement('select');
@@ -223,7 +222,10 @@ async function createBigfootSightingsMap() {
     selectNumBigfoot.appendChild(optionElement);
   }
   messageContainer.appendChild(selectNumBigfoot);
+}
 
+/** Fetches bigfoot sightings data from the server and displays it in a map. */
+async function createBigfootSightingsMap() {
   const response = await fetch('/bigfoot-data');
   const bigfootSightings = await response.json();
 
@@ -314,6 +316,7 @@ function selectMap() {
   if (option == "user") {
     createUserInputMap();
   } else {
+    createNumBigfootSelect();
     createBigfootSightingsMap();
   }
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -215,6 +215,7 @@ function createNumBigfootSelect() {
   const messageContainer = document.getElementById("map-descriptor");
   messageContainer.innerText = "Choose number of random sightings of bigfoot to display 🦧:"
   const selectNumBigfoot = document.createElement('select');
+  selectNumBigfoot.id = "num-bigfoot";
   const SELECT_OPTIONS = ["100", "1000", "2000", "all"];
 
   for (let i = 0; i < SELECT_OPTIONS.length; i++) {
@@ -226,7 +227,8 @@ function createNumBigfootSelect() {
 
 /** Fetches bigfoot sightings data from the server and displays it in a map. */
 async function createBigfootSightingsMap() {
-  const response = await fetch('/bigfoot-data');
+  const numBigfoot = document.getElementById("num-bigfoot").value;
+  const response = await fetch('/bigfoot-data?num-bigfoot='+numBigfoot);
   const bigfootSightings = await response.json();
 
   const map = new google.maps.Map(

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -216,7 +216,8 @@ function createNumBigfootSelect() {
   messageContainer.innerText = "Choose number of random sightings of bigfoot to display 🦧:"
   const selectNumBigfoot = document.createElement('select');
   selectNumBigfoot.id = "num-bigfoot";
-  const SELECT_OPTIONS = ["100", "1000", "2000", "all"];
+  selectNumBigfoot.setAttribute("onchange", "createBigfootSightingsMap()");
+  const SELECT_OPTIONS = ["100", "500", "1000", "2000", "all"];
 
   for (let i = 0; i < SELECT_OPTIONS.length; i++) {
     const optionElement = createOptionElement(SELECT_OPTIONS[i]);
@@ -228,7 +229,7 @@ function createNumBigfootSelect() {
 /** Fetches bigfoot sightings data from the server and displays it in a map. */
 async function createBigfootSightingsMap() {
   const numBigfoot = document.getElementById("num-bigfoot").value;
-  const response = await fetch('/bigfoot-data?num-bigfoot='+numBigfoot);
+  const response = await fetch('/bigfoot-data?num-bigfoot=' + numBigfoot);
   const bigfootSightings = await response.json();
 
   const map = new google.maps.Map(

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -204,10 +204,25 @@ function createUserInputMap() {
   getMarkersfromServer();
 }
 
+function createOptionElement(value) {
+  const optionElement = document.createElement('option');
+  optionElement.innerText = value;
+  optionElement.setAttribute("value", value);
+  return optionElement
+}
+
 /** Fetches bigfoot sightings data from the server and displays it in a map. */
 async function createBigfootSightingsMap() {
   const messageContainer = document.getElementById("map-descriptor");
-  messageContainer.innerText = "This is locations of Bigfoot sightings 🦧";
+  messageContainer.innerText = "Choose number of random sightings of bigfoot to display 🦧:"
+  const selectNumBigfoot = document.createElement('select');
+  const SELECT_OPTIONS = ["100", "1000", "2000", "all"];
+
+  for (let i = 0; i < SELECT_OPTIONS.length; i++) {
+    const optionElement = createOptionElement(SELECT_OPTIONS[i]);
+    selectNumBigfoot.appendChild(optionElement);
+  }
+  messageContainer.appendChild(selectNumBigfoot);
 
   const response = await fetch('/bigfoot-data');
   const bigfootSightings = await response.json();


### PR DESCRIPTION
Because there are around 3000 datapoint, when all the data is shown, too much markers are clustered together. Hence, I added a feature where users can choose number of bigfoot sightings to be displayed. Sightings displayed is random because it gets shuffled every time. 
![Screenshot 2020-06-19 at 8 03 25 AM - Display 1](https://user-images.githubusercontent.com/43098355/85080297-c6e89a00-b203-11ea-85e0-7e2ee43ee9de.png)
