### PR TITLE
Fix bug of skipping overlap check

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -33,7 +33,8 @@ public final class FindMeetingQuery {
       if (!Collections.disjoint(event.getAttendees(), attendees)) {
         TimeRange eventTime = event.getWhen();
         
-        for (int i = 0; i < possibleMeetingTimes.size(); i++) {
+        int i = 0;
+        while (i < possibleMeetingTimes.size()) {
           TimeRange currentTime = possibleMeetingTimes.get(i);
           if (currentTime.overlaps(eventTime)) {
             possibleMeetingTimes.remove(i);
@@ -51,6 +52,9 @@ public final class FindMeetingQuery {
                 possibleMeetingTimes.add(TimeRange.fromStartDuration(eventTime.end(), duration));
               }
             }
+          }
+          else {
+            i++;
           }
         }
       }


### PR DESCRIPTION
Previously, when looping with for loop since we modify the array in the loop (adding and removing the element), there is a possibility of skipping a TimeRange when checking for overlap. For instance, if we remove index 0 element, then in the next iteration of the loop the previously index 1 element now becomes index 0 element, therefore is never going to be checked in the for loop. To fix this problem, first, for loop is changed to while loop, and index is incremented only if there was no change in array element. 