### PR TITLE
Fix bug of skipping overlap check

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -47,7 +47,8 @@ public final class FindMeetingQuery {
       if (!Collections.disjoint(event.getAttendees(), attendees)) {
         TimeRange eventTime = event.getWhen();
         
-        for (int i = 0; i < possibleMeetingTimes.size(); i++) {
+        int i = 0;
+        while (i < possibleMeetingTimes.size()) {
           TimeRange currentTime = possibleMeetingTimes.get(i);
           if (currentTime.overlaps(eventTime)) {
             possibleMeetingTimes.remove(i);
@@ -65,6 +66,9 @@ public final class FindMeetingQuery {
                 possibleMeetingTimes.add(TimeRange.fromStartDuration(eventTime.end(), duration));
               }
             }
+          }
+          else {
+            i++;
           }
         }
       }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -415,5 +415,32 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
+
+  @Test
+  public void notEnoughRoomWithThreeAttendees() {
+    // Have three mandatory people, but so that there is not enough room at any point in the day to have
+    // the meeting. Let last event be the whole day event overlapping previous two events. 
+    //
+    // Events  :       |--A--|     |--B--|
+    //           |-------------C---------------|
+    // Day     : |-----------------------------|
+    // Options :   
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.WHOLE_DAY, 
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B, PERSON_C), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
 }
 


### PR DESCRIPTION
Previously, when looping with for loop since we modify the array in the loop (adding and removing the element), there is a possibility of skipping a TimeRange when checking for overlap. For instance, if we remove index 0 element, then in the next iteration of the loop the previously index 1 element now becomes index 0 element, therefore is never going to be checked in the for loop. To fix this problem, first, for loop is changed to while loop, and index is incremented only if there was no change in array element.